### PR TITLE
Add Client constructors without access token

### DIFF
--- a/src/main/java/org/reduct/client/ReductClient.java
+++ b/src/main/java/org/reduct/client/ReductClient.java
@@ -20,9 +20,6 @@ public abstract class ReductClient {
       if (serverProperties == null) {
          throw new IllegalArgumentException("ServerProperties cannot be null.");
       }
-      if (accessToken == null || accessToken.isBlank()) {
-         throw new IllegalArgumentException("Access token cannot be null or empty.");
-      }
       this.serverProperties = serverProperties;
       this.httpClient = httpClient;
       this.objectMapper = objectMapper;

--- a/src/main/java/org/reduct/client/ReductServerClient.java
+++ b/src/main/java/org/reduct/client/ReductServerClient.java
@@ -16,10 +16,21 @@ import java.net.http.HttpResponse;
 public class ReductServerClient extends ReductClient implements ServerClient {
 
    /**
+    * Constructs a new ReductServerClient with the given properties.
+    * NOTE: Client created without access token will not be able to interact with the server if,
+    * authentication is enabled on the server.
+    *
+    * @param serverProperties The properties, such as host and port
+    */
+   public ReductServerClient(ServerProperties serverProperties) {
+      this(serverProperties, null);
+   }
+
+   /**
     * Constructs a new ReductServerClient with the given properties and the given access token.
     *
     * @param serverProperties The properties, such as host and port
-    * @param accessToken            The access token to use for authentication
+    * @param accessToken      The access token to use for authentication
     */
    public ReductServerClient(ServerProperties serverProperties, String accessToken) {
       this(serverProperties, HttpClient.newHttpClient(), accessToken);

--- a/src/main/java/org/reduct/client/ReductTokenClient.java
+++ b/src/main/java/org/reduct/client/ReductTokenClient.java
@@ -17,6 +17,17 @@ import java.net.http.HttpResponse;
 public class ReductTokenClient extends ReductClient implements TokenClient {
 
    /**
+    * Constructs a new ReductTokenClient with the given properties.
+    * NOTE: Client created without access token will not be able to interact with the server if,
+    * authentication is enabled on the server.
+    *
+    * @param serverProperties The properties, such as host and port
+    */
+   public ReductTokenClient(ServerProperties serverProperties) {
+      this(serverProperties, null);
+   }
+
+   /**
     * Constructs a new ReductTokenClient with the given properties and the given access token.
     *
     * @param serverProperties The properties, such as host and port

--- a/src/test/java/org/reduct/client/ReductServerClientTest.java
+++ b/src/test/java/org/reduct/client/ReductServerClientTest.java
@@ -127,22 +127,6 @@ class ReductServerClientTest {
    }
 
    @Test
-   void constructClient_accessTokenIsNull_throwException() {
-      IllegalArgumentException result = assertThrows(IllegalArgumentException.class,
-              () -> new ReductServerClient(serverProperties, httpClient, null));
-
-      assertEquals("Access token cannot be null or empty.", result.getMessage());
-   }
-
-   @Test
-   void constructClient_accessTokenIsEmpty_throwException() {
-      IllegalArgumentException result = assertThrows(IllegalArgumentException.class,
-              () -> new ReductServerClient(serverProperties, httpClient, ""));
-
-      assertEquals("Access token cannot be null or empty.", result.getMessage());
-   }
-
-   @Test
    void constructClient_serverPropertiesIsNull_throwException() {
       IllegalArgumentException result = assertThrows(IllegalArgumentException.class,
               () -> new ReductServerClient(null, httpClient, accessToken));

--- a/src/test/java/org/reduct/client/ReductTokenClientTest.java
+++ b/src/test/java/org/reduct/client/ReductTokenClientTest.java
@@ -189,18 +189,6 @@ class ReductTokenClientTest {
               () -> new ReductTokenClient(null, httpClient, accessToken));
    }
 
-   @Test
-   void constructClient_accessTokenIsNull_throwException() {
-      assertThrows(IllegalArgumentException.class,
-              () -> new ReductTokenClient(serverProperties, httpClient, null));
-   }
-
-   @Test
-   void constructClient_accessTokenIsEmpty_throwException() {
-      assertThrows(IllegalArgumentException.class,
-              () -> new ReductTokenClient(serverProperties, httpClient, ""));
-   }
-
    private HttpRequest buildCreateTokenRequest() {
       String createTokenPath = TokenURL.CREATE_TOKEN.getUrl().formatted(TOKEN_NAME);
       URI createTokenUri = URI.create("%s/%s".formatted(serverProperties.getBaseUrl(), createTokenPath));


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Allow clients be instantiated without access token to interact with server(s) with disabled authentication.

### What is the current behavior?

Access token is required.

### What is the new behavior?

A new constructor has been introduced that does not take access token.

