### PR TITLE
Refactor Clients to use x-reduct-error header value

### DIFF
--- a/src/main/java/org/reduct/client/BucketClient.java
+++ b/src/main/java/org/reduct/client/BucketClient.java
@@ -28,5 +28,6 @@ public interface BucketClient {
     * @throws ReductSDKException       If, any client side error occur.
     * @throws IllegalArgumentException If, the bucket name is null or empty.
     */
-   String createBucket(String bucketName, BucketSettings bucketSettings) throws ReductException, ReductSDKException;
+   String createBucket(String bucketName, BucketSettings bucketSettings)
+           throws ReductException, ReductSDKException, IllegalArgumentException;
 }

--- a/src/main/java/org/reduct/client/ReductBucketClient.java
+++ b/src/main/java/org/reduct/client/ReductBucketClient.java
@@ -48,7 +48,8 @@ public class ReductBucketClient extends ReductClient implements BucketClient {
    }
 
    @Override
-   public String createBucket(String bucketName, BucketSettings bucketSettings) {
+   public String createBucket(String bucketName, BucketSettings bucketSettings)
+           throws ReductException, ReductSDKException, IllegalArgumentException {
       if (bucketName == null || bucketName.isBlank()) {
          throw new IllegalArgumentException("Bucket name cannot be null or empty");
       }

--- a/src/main/java/org/reduct/client/ReductServerClient.java
+++ b/src/main/java/org/reduct/client/ReductServerClient.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.reduct.client.config.ServerProperties;
 import org.reduct.common.ServerURL;
 import org.reduct.common.exception.ReductException;
+import org.reduct.common.exception.ReductSDKException;
 import org.reduct.model.server.ServerInfo;
 
 import java.io.IOException;
@@ -14,6 +15,8 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
 public class ReductServerClient extends ReductClient implements ServerClient {
+
+   private static final String REDUCT_ERROR_HEADER = "x-reduct-error";
 
    /**
     * Constructs a new ReductServerClient with the given properties.
@@ -41,21 +44,21 @@ public class ReductServerClient extends ReductClient implements ServerClient {
    }
 
    @Override
-   public ServerInfo getServerInfo() {
+   public ServerInfo getServerInfo() throws ReductException, ReductSDKException {
       URI serverInfoUri = URI.create("%s/%s".formatted(serverProperties.getBaseUrl(), ServerURL.SERVER_INFO.getUrl()));
       HttpRequest getRequest = HttpRequest.newBuilder()
               .GET()
               .uri(serverInfoUri)
               .header("Authorization", "Bearer %s".formatted(token))
               .build();
-      HttpResponse<String> response = sendRequest(getRequest);
-      if (response.statusCode() == 200) {
-         return parseServerInfo(response.body());
-      } else if (response.statusCode() == 401) {
-         throw new ReductException("The access token is invalid.", response.statusCode());
+      HttpResponse<String> httpResponse = sendRequest(getRequest);
+      if (httpResponse.statusCode() == 200) {
+         return parseServerInfo(httpResponse.body());
       } else {
-         throw new ReductException("The server returned an unexpected response. Please try again later.",
-                 response.statusCode());
+         String errorMessage = httpResponse.headers()
+                 .firstValue(REDUCT_ERROR_HEADER)
+                 .orElse("Failed to create bucket");
+         throw new ReductException(errorMessage, httpResponse.statusCode());
       }
    }
 
@@ -63,10 +66,10 @@ public class ReductServerClient extends ReductClient implements ServerClient {
       try {
          return httpClient.send(getRequest, HttpResponse.BodyHandlers.ofString());
       } catch (IOException e) {
-         throw new ReductException("An error occurred while processing the request", e);
+         throw new ReductSDKException("An error occurred while processing the request", e);
       } catch (InterruptedException e) {
          Thread.currentThread().interrupt();
-         throw new ReductException("Thread has been interrupted while processing the request", e);
+         throw new ReductSDKException("Thread has been interrupted while processing the request", e);
       }
    }
 
@@ -74,7 +77,7 @@ public class ReductServerClient extends ReductClient implements ServerClient {
       try {
          return objectMapper.readValue(serverInfo, ServerInfo.class);
       } catch (JacksonException e) {
-         throw new ReductException("The server returned a malformed response.");
+         throw new ReductSDKException("The server returned a malformed response.");
       }
    }
 }

--- a/src/main/java/org/reduct/client/ReductTokenClient.java
+++ b/src/main/java/org/reduct/client/ReductTokenClient.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.reduct.client.config.ServerProperties;
 import org.reduct.common.TokenURL;
 import org.reduct.common.exception.ReductException;
+import org.reduct.common.exception.ReductSDKException;
 import org.reduct.model.token.AccessToken;
 import org.reduct.model.token.TokenPermissions;
 
@@ -44,7 +45,8 @@ public class ReductTokenClient extends ReductClient implements TokenClient {
    }
 
    @Override
-   public AccessToken createToken(String tokenName, TokenPermissions permissions) throws ReductException {
+   public AccessToken createToken(String tokenName, TokenPermissions permissions)
+           throws ReductException, ReductSDKException, IllegalArgumentException {
       if (tokenName == null || tokenName.isBlank()) {
          throw new IllegalArgumentException("Token name must not be null or blank");
       }
@@ -69,10 +71,10 @@ public class ReductTokenClient extends ReductClient implements TokenClient {
       try {
          return httpClient.send(createTokenRequest, HttpResponse.BodyHandlers.ofString());
       } catch (IOException e) {
-         throw new ReductException("An error occurred while processing the request", e);
+         throw new ReductSDKException("An error occurred while processing the request", e);
       } catch (InterruptedException e) {
          Thread.currentThread().interrupt();
-         throw new ReductException("Thread has been interrupted while processing the request", e);
+         throw new ReductSDKException("Thread has been interrupted while processing the request", e);
       }
    }
 
@@ -93,7 +95,7 @@ public class ReductTokenClient extends ReductClient implements TokenClient {
       try {
          return objectMapper.writeValueAsString(permissions);
       } catch (JsonProcessingException e) {
-         throw new ReductException("Failed to serialize the token permissions.", e);
+         throw new ReductSDKException("Failed to serialize the token permissions.", e);
       }
    }
 
@@ -101,7 +103,7 @@ public class ReductTokenClient extends ReductClient implements TokenClient {
       try {
          return objectMapper.readValue(body, AccessToken.class);
       } catch (JsonProcessingException e) {
-         throw new ReductException("The server returned a malformed response.", e);
+         throw new ReductSDKException("The server returned a malformed response.", e);
       }
    }
 }

--- a/src/main/java/org/reduct/client/ServerClient.java
+++ b/src/main/java/org/reduct/client/ServerClient.java
@@ -1,5 +1,7 @@
 package org.reduct.client;
 
+import org.reduct.common.exception.ReductException;
+import org.reduct.common.exception.ReductSDKException;
 import org.reduct.model.server.ServerInfo;
 
 public interface ServerClient {
@@ -7,8 +9,12 @@ public interface ServerClient {
    /**
     * Attempts to retrieve the server information. Such as, version, bucket count, usage, uptime, oldest record,
     * latest record, and default settings.
-    * Returns {@link org.reduct.model.server.ServerInfo} object if the request is successful.
-    * Throws {@link org.reduct.common.exception.ReductException} if the request fails.
+    *
+    * @return {@link ServerInfo} object if the request is successful.
+    * @throws ReductException    if the request fails. The instance of the exception holds
+    *                            the error message returned in the x-reduct-error header and the
+    *                            status code to indicate the failure.
+    * @throws ReductSDKException If, any client side error occurs.
     */
-   ServerInfo getServerInfo();
+   ServerInfo getServerInfo() throws ReductException, ReductSDKException;
 }

--- a/src/main/java/org/reduct/client/TokenClient.java
+++ b/src/main/java/org/reduct/client/TokenClient.java
@@ -1,6 +1,7 @@
 package org.reduct.client;
 
 import org.reduct.common.exception.ReductException;
+import org.reduct.common.exception.ReductSDKException;
 import org.reduct.model.token.AccessToken;
 import org.reduct.model.token.TokenPermissions;
 
@@ -15,11 +16,15 @@ public interface TokenClient {
     * @param tokenName   The name of the token to create.
     * @param permissions The permissions to give to the token. Such as, whether it has full access to the server,
     *                    or only read access to some buckets, or write access to some buckets.
-    * @return {@link org.reduct.model.token.AccessToken} object that holds the token and the creation date.
+    * @return {@link AccessToken} object that holds the token and the creation date.
     * @throws ReductException          If the request fails, for example the token already exists, or
     *                                  any of the buckets listed does not exist on the server.
+    *                                  The instance of the exception holds the error message returned in
+    *                                  the x-reduct-error header and the status code to indicate the failure.
+    * @throws ReductSDKException       If, any client side error occurs.
     * @throws IllegalArgumentException If the token name is null or blank, or if the
     *                                  {@link org.reduct.model.token.TokenPermissions} object is null.
     */
-   AccessToken createToken(String tokenName, TokenPermissions permissions) throws ReductException;
+   AccessToken createToken(String tokenName, TokenPermissions permissions)
+           throws ReductException, ReductSDKException, IllegalArgumentException;
 }

--- a/src/test/java/org/reduct/client/ReductServerClientTest.java
+++ b/src/test/java/org/reduct/client/ReductServerClientTest.java
@@ -8,18 +8,23 @@ import org.reduct.client.config.ServerProperties;
 import org.reduct.client.util.ServerInfoConstants;
 import org.reduct.common.ServerURL;
 import org.reduct.common.exception.ReductException;
+import org.reduct.common.exception.ReductSDKException;
 import org.reduct.model.server.ServerInfo;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class ReductServerClientTest {
+
+   private static final String REDUCT_ERROR_HEADER = "x-reduct-error";
 
    private ServerProperties serverProperties;
    private HttpClient httpClient;
@@ -36,11 +41,7 @@ class ReductServerClientTest {
 
    @Test
    void getServerInfo_validDetails_returnServerInfo() throws IOException, InterruptedException {
-      HttpRequest httpRequest = HttpRequest.newBuilder()
-              .uri(URI.create("%s/%s".formatted(serverProperties.getBaseUrl(), ServerURL.SERVER_INFO.getUrl())))
-              .GET()
-              .header("Authorization", "Bearer %s".formatted(accessToken))
-              .build();
+      HttpRequest httpRequest = createHttpRequest();
       HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
       doReturn(200).when(mockHttpResponse).statusCode();
       doReturn(ServerInfoConstants.SUCCESSFUL_SERVER_INFO_RESPONSE).when(mockHttpResponse).body();
@@ -52,77 +53,49 @@ class ReductServerClientTest {
    }
 
    @Test
-   void getServerInfo_serverUnavailable_throwException() throws IOException, InterruptedException {
-      HttpRequest httpRequest = HttpRequest.newBuilder()
-              .uri(URI.create("%s/%s".formatted(serverProperties.getBaseUrl(), ServerURL.SERVER_INFO.getUrl())))
-              .GET()
-              .header("Authorization", "Bearer %s".formatted(accessToken))
-              .build();
-      HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
-      doReturn(503).when(mockHttpResponse).statusCode();
-      doReturn(ServerInfoConstants.SUCCESSFUL_SERVER_INFO_RESPONSE).when(mockHttpResponse).body();
-      doReturn(mockHttpResponse).when(httpClient).send(httpRequest, HttpResponse.BodyHandlers.ofString());
-      ReductException result = assertThrows(ReductException.class, () -> reductServerClient.getServerInfo());
-
-      assertEquals("The server returned an unexpected response. Please try again later.", result.getMessage());
-      assertEquals(503, result.getStatusCode());
-   }
-
-   @Test
    void getServerInfo_serverReturnsMalformedJson_throwException() throws IOException, InterruptedException {
-      HttpRequest httpRequest = HttpRequest.newBuilder()
-              .uri(URI.create("%s/%s".formatted(serverProperties.getBaseUrl(), ServerURL.SERVER_INFO.getUrl())))
-              .GET()
-              .header("Authorization", "Bearer %s".formatted(accessToken))
-              .build();
+      HttpRequest httpRequest = createHttpRequest();
       HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
       doReturn(200).when(mockHttpResponse).statusCode();
       doReturn("{{}").when(mockHttpResponse).body();
       doReturn(mockHttpResponse).when(httpClient).send(httpRequest, HttpResponse.BodyHandlers.ofString());
-      ReductException result = assertThrows(ReductException.class, () -> reductServerClient.getServerInfo());
+      ReductSDKException result = assertThrows(ReductSDKException.class, () -> reductServerClient.getServerInfo());
 
       assertEquals("The server returned a malformed response.", result.getMessage());
    }
 
    @Test
    void getServerInfo_ioExceptionOccurs_throwException() throws IOException, InterruptedException {
-      HttpRequest httpRequest = HttpRequest.newBuilder()
-              .uri(URI.create("%s/%s".formatted(serverProperties.getBaseUrl(), ServerURL.SERVER_INFO.getUrl())))
-              .GET()
-              .header("Authorization", "Bearer %s".formatted(accessToken))
-              .build();
+      HttpRequest httpRequest = createHttpRequest();
       doThrow(IOException.class).when(httpClient).send(httpRequest, HttpResponse.BodyHandlers.ofString());
-      ReductException result = assertThrows(ReductException.class, () -> reductServerClient.getServerInfo());
+      ReductSDKException result = assertThrows(ReductSDKException.class, () -> reductServerClient.getServerInfo());
 
       assertEquals("An error occurred while processing the request", result.getMessage());
    }
 
    @Test
    void getServerInfo_threadInterrupted_throwException() throws IOException, InterruptedException {
-      HttpRequest httpRequest = HttpRequest.newBuilder()
-              .uri(URI.create("%s/%s".formatted(serverProperties.getBaseUrl(), ServerURL.SERVER_INFO.getUrl())))
-              .GET()
-              .header("Authorization", "Bearer %s".formatted(accessToken))
-              .build();
+      HttpRequest httpRequest = createHttpRequest();
       doThrow(InterruptedException.class).when(httpClient).send(httpRequest, HttpResponse.BodyHandlers.ofString());
-      ReductException result = assertThrows(ReductException.class, () -> reductServerClient.getServerInfo());
+      ReductSDKException result = assertThrows(ReductSDKException.class, () -> reductServerClient.getServerInfo());
 
       assertEquals("Thread has been interrupted while processing the request", result.getMessage());
    }
 
    @Test
    void getServerInfo_invalidToken_throwException() throws IOException, InterruptedException {
-      HttpRequest httpRequest = HttpRequest.newBuilder()
-              .uri(URI.create("%s/%s".formatted(serverProperties.getBaseUrl(), ServerURL.SERVER_INFO.getUrl())))
-              .GET()
-              .header("Authorization", "Bearer %s".formatted(accessToken))
-              .build();
+      HttpRequest httpRequest = createHttpRequest();
       HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
+      Optional<String> errorHeader = Optional.of("Invalid token");
+      HttpHeaders mockHttpHeaders = mock(HttpHeaders.class);
+
+      doReturn(mockHttpHeaders).when(mockHttpResponse).headers();
+      doReturn(errorHeader).when(mockHttpHeaders).firstValue(REDUCT_ERROR_HEADER);
       doReturn(401).when(mockHttpResponse).statusCode();
       doReturn(mockHttpResponse).when(httpClient).send(httpRequest, HttpResponse.BodyHandlers.ofString());
       ReductException result = assertThrows(ReductException.class, () -> reductServerClient.getServerInfo());
 
-      assertEquals("The access token is invalid.", result.getMessage());
+      assertEquals("Invalid token", result.getMessage());
       assertEquals(401, result.getStatusCode());
    }
 
@@ -132,6 +105,14 @@ class ReductServerClientTest {
               () -> new ReductServerClient(null, httpClient, accessToken));
 
       assertEquals("ServerProperties cannot be null.", result.getMessage());
+   }
+
+   private HttpRequest createHttpRequest() {
+      return HttpRequest.newBuilder()
+              .uri(URI.create("%s/%s".formatted(serverProperties.getBaseUrl(), ServerURL.SERVER_INFO.getUrl())))
+              .GET()
+              .header("Authorization", "Bearer %s".formatted(accessToken))
+              .build();
    }
 
    private ServerInfo sampleServerInfo() throws JsonProcessingException {

--- a/src/test/java/org/reduct/client/ReductTokenClientTest.java
+++ b/src/test/java/org/reduct/client/ReductTokenClientTest.java
@@ -6,6 +6,7 @@ import org.reduct.client.config.ServerProperties;
 import org.reduct.client.util.TokenConstants;
 import org.reduct.common.TokenURL;
 import org.reduct.common.exception.ReductException;
+import org.reduct.common.exception.ReductSDKException;
 import org.reduct.model.token.AccessToken;
 import org.reduct.model.token.TokenPermissions;
 
@@ -83,7 +84,7 @@ class ReductTokenClientTest {
       doReturn("{{}").when(httpResponse).body();
       doReturn(httpResponse).when(httpClient).send(httpRequest, HttpResponse.BodyHandlers.ofString());
 
-      ReductException reductException = assertThrows(ReductException.class,
+      ReductSDKException reductException = assertThrows(ReductSDKException.class,
               () -> reductTokenClient.createToken(TOKEN_NAME,
                       TokenPermissions.of(true, List.of("test-bucket"), List.of("test-bucket"))));
 
@@ -95,7 +96,7 @@ class ReductTokenClientTest {
    void createToken_ioExceptionOccurs_throwException() throws IOException, InterruptedException {
       HttpRequest httpRequest = buildCreateTokenRequest();
       doThrow(IOException.class).when(httpClient).send(httpRequest, HttpResponse.BodyHandlers.ofString());
-      ReductException result = assertThrows(ReductException.class, () -> reductTokenClient.createToken(TOKEN_NAME,
+      ReductSDKException result = assertThrows(ReductSDKException.class, () -> reductTokenClient.createToken(TOKEN_NAME,
               TokenPermissions.of(true, List.of("test-bucket"), List.of("test-bucket"))));
 
       assertEquals("An error occurred while processing the request", result.getMessage());
@@ -105,7 +106,7 @@ class ReductTokenClientTest {
    void createToken_threadInterrupted_throwException() throws IOException, InterruptedException {
       HttpRequest httpRequest = buildCreateTokenRequest();
       doThrow(InterruptedException.class).when(httpClient).send(httpRequest, HttpResponse.BodyHandlers.ofString());
-      ReductException result = assertThrows(ReductException.class,
+      ReductSDKException result = assertThrows(ReductSDKException.class,
               () -> reductTokenClient.createToken(TOKEN_NAME,
                       TokenPermissions.of(true, List.of("test-bucket"), List.of("test-bucket"))));
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

- The remaining client classes refactored to use the x-reduct-error header value returned by the server.
- Client classes refactored to use ReductSDKException.
- Javadocs updated.
